### PR TITLE
feat: Restore email

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1034,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flagset"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,7 +1238,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.10",
  "indexmap 1.9.3",
  "slab",
  "tokio",
@@ -1319,13 +1331,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.10",
  "pin-project-lite",
 ]
 
@@ -1358,7 +1381,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.10",
  "http-body",
  "httparse",
  "httpdate",
@@ -1378,11 +1401,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.10",
  "hyper",
- "rustls",
+ "rustls 0.21.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -1547,9 +1570,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jmap-client"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9269c3a9666d47c2a2bc8e60f50aa7e0f3745a5810ec13672ed947246b018d"
+checksum = "12c697483ad894a8184d0fd61848e057f86b16642049993b3e6a80c959dbc90a"
 dependencies = [
  "ahash",
  "async-stream",
@@ -1559,8 +1582,12 @@ dependencies = [
  "maybe-async",
  "parking_lot",
  "reqwest",
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "serde",
  "serde_json",
+ "tokio",
+ "tokio-tungstenite",
 ]
 
 [[package]]
@@ -2041,7 +2068,7 @@ dependencies = [
  "flagset",
  "futures",
  "getrandom",
- "http",
+ "http 0.2.10",
  "log",
  "md-5",
  "once_cell",
@@ -2229,6 +2256,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.1.0",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,6 +2410,7 @@ dependencies = [
  "mail-parser",
  "open",
  "opendal",
+ "petgraph",
  "prettytable-rs",
  "rayon",
  "serde",
@@ -2585,7 +2623,7 @@ dependencies = [
  "hex",
  "hmac",
  "home",
- "http",
+ "http 0.2.10",
  "jsonwebtoken",
  "log",
  "once_cell",
@@ -2613,7 +2651,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.10",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -2624,7 +2662,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.8",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde",
@@ -2632,7 +2670,7 @@ dependencies = [
  "serde_urlencoded",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -2640,7 +2678,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.2",
  "winreg",
 ]
 
@@ -2768,8 +2806,22 @@ checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2794,12 +2846,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -3454,8 +3523,35 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.8",
  "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tungstenite",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -3591,6 +3687,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3661,6 +3778,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-ranges"
@@ -3811,6 +3934,15 @@ name = "webpki-roots"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ env_logger = "0.11.2"
 futures = "0.3.29"
 indicatif = "0.17.7"
 indicatif-log-bridge = "0.2.2"
-jmap-client = { version = "0.3.0", features = ["async"] }
+jmap-client = { version = "0.3.2", features = ["async"] }
 keyring = "2.0.5"
 lazy_static = "1.4.0"
 log = "0.4"
@@ -31,3 +31,4 @@ serde_json = "1.0.108"
 tantivy = "0.21.1"
 tempfile = "3.10.1"
 tokio = { version = "1.34.0", features = ["full"] }
+petgraph = "0.6.5"

--- a/src/cli/backup.rs
+++ b/src/cli/backup.rs
@@ -6,7 +6,7 @@ use log::info;
 use opendal::Operator;
 use tantivy::IndexWriter;
 
-use crate::core::email::emails;
+use crate::core::email::backup_emails;
 use crate::core::mailboxes::mailboxes;
 use crate::core::helpers;
 use crate::core::progress::Progressable;
@@ -55,7 +55,7 @@ pub async fn backup(client: Client, operator: Operator, multi: MultiProgress, in
     mailboxes(&client, &operator, max_objects, &pb_mailboxes).await?;
 
     // Process emails
-    emails(&client, &operator, max_objects, &pb_emails, indexer).await?;
+    backup_emails(&client, &operator, max_objects, &pb_emails, indexer).await?;
 
 
     // Print mailboxes

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -19,12 +19,27 @@ pub struct Cli {
     pub command: Option<Commands>,
 }
 
+#[derive(Subcommand)]
+pub enum RestoreCommands {
+    /// Restore email
+    Email {
+        /// Email id
+        id: String,
+    },
+    
+}
+
 
 #[derive(Subcommand)]
 pub enum Commands {
     /// Backup JMAP data from a JMAP server
     Backup {},
 
+    /// Restore JMAP data to a JMAP server
+    Restore {
+        #[command(subcommand)]
+        cmd: RestoreCommands,
+    },
     /// Show the status of the backup, i.e. what was the last message backed up
     Status {},
 

--- a/src/core/helpers.rs
+++ b/src/core/helpers.rs
@@ -1,7 +1,45 @@
-use jmap_client::client::Client;
+use std::collections::HashMap;
+use jmap_client::{client::Client, mailbox::Mailbox};
+use petgraph::{algo::toposort, graph::DiGraph};
 
 // Borrow client to get max_objects_in_get, return usize
 pub fn max_objects_in_get(client: &Client) -> usize {
     // Return min of 100 or max_objects_in_get
     client.session().core_capabilities().map(|c| c.max_objects_in_get()).unwrap_or(50).min(50)
+}
+
+pub fn sort_mailboxes(mailboxes: Vec<Mailbox>) -> anyhow::Result<Vec<Mailbox>> {
+    // Sort the mailboxes so that any parent mailboxes are restored first
+    // Essentially if a is parent of b, and b is parent of c, then a should be restored first, then b, then c
+    // Each mailbox can be parent to multiple mailboxes
+    let mut graph = DiGraph::new();
+    let mut node_indices = HashMap::new();
+    
+    // Add nodes to the graph
+    for mailbox in mailboxes.iter() {
+        node_indices.insert(mailbox.id().unwrap_or_default(), graph.add_node(mailbox.id().unwrap()));
+    }
+
+    // Add edges to the graph
+    for mailbox in mailboxes.iter() {
+        if let Some(parent_id) = mailbox.parent_id() {
+            if let Some(&parent_index) = node_indices.get(parent_id) {
+                let child_index = *node_indices.get(mailbox.id().unwrap_or_default()).unwrap();
+                graph.add_edge(parent_index, child_index, ());
+            }
+        }
+    }
+
+    let sorted_indices = toposort(&graph, None)
+        .map_err(|e| anyhow::anyhow!("Error sorting mailboxes: cycle detected at node {:?}", e.node_id()))?;
+    
+    // Map the sorted indices back to mailboxes
+    let mut sorted_mailboxes = Vec::new();
+    for index in sorted_indices {
+        let id = graph.node_weight(index).unwrap();
+        let mailbox = mailboxes.iter().find(|m| m.id().unwrap_or_default() == *id).unwrap();
+        sorted_mailboxes.push(mailbox.clone());
+    }
+
+    Ok(sorted_mailboxes)
 }

--- a/src/core/jmap.rs
+++ b/src/core/jmap.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use jmap_client::client::{Client, Credentials};
+use jmap_client::{client::{Client, Credentials}, mailbox::Mailbox};
 
 use crate::conf::{self, AuthMode};
 
@@ -32,3 +32,58 @@ pub async fn create_client(jmap_conf: conf::Jmap) -> anyhow::Result<Client> {
 
     Ok(client)
 }
+
+
+/// A helper function to fetch mailboxes from the JMAP server
+/// Returns as many mailboxes as max_objects or less
+pub async fn fetch_mailboxes(
+    position: usize,
+    max_objects: usize,
+    client: &Client,
+) -> anyhow::Result<Vec<Mailbox>> {
+    let mut request = client.build();
+    let result = request
+        .query_mailbox()
+        .position(position.try_into().unwrap())
+        .limit(max_objects)
+        .result_reference();
+
+    request.get_mailbox().ids_ref(result);
+
+    let mut response = request.send().await?.unwrap_method_responses();
+    let mailboxes_res = response.pop();
+
+    match mailboxes_res {
+        // Match Vec of two TaggedMethodResponse
+        Some(mailboxes_res) => {
+            let mailboxes = mailboxes_res.unwrap_get_mailbox()?.take_list();
+            Ok(mailboxes)
+        }
+        _ => anyhow::bail!("unexpected number of responses"),
+    }
+}
+
+/// A helper function that creates a mailbox on the JMAP server
+pub async fn create_mailboxes(
+    client: &Client,
+    mailboxes: Vec<Mailbox>,
+) -> anyhow::Result<()> {
+    let mut request = client.build();
+    let set_request = request.set_mailbox();
+
+    for mailbox in mailboxes {
+        set_request
+            .create()
+            .name(mailbox.name().unwrap_or_default())
+            .role(mailbox.role())
+            .parent_id(mailbox.parent_id());
+    }
+
+    let response = request
+        .send_set_mailbox()
+        .await?
+        .unwrap_create_errors()
+        .with_context(|| "Error creating mailboxes")?;
+
+    Ok(())
+} 

--- a/src/core/storage.rs
+++ b/src/core/storage.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::Context;
+use jmap_client::{email::Email, mailbox::Mailbox};
 use opendal::{layers::RetryLayer, Operator, Scheme};
 
 /**
@@ -18,3 +19,28 @@ pub fn create_storage_backend(scheme: Scheme, config: HashMap<String, String>) -
     Ok(retry_operator)
 }
 
+pub async fn get_email_from_storage(operator: &Operator, id: &str) -> anyhow::Result<Email> {
+    let path = format!("/emails/{}/{}.json", &id[..3], id);
+    let json = operator
+        .read(&path)
+        .await
+        .with_context(|| format!("Error reading email {}", id))?;
+
+    let email = serde_json::from_slice::<Email>(&json)
+        .with_context(|| format!("Error deserializing email {}", id))?;
+
+    Ok(email)
+}
+
+pub async fn get_mailbox_from_storage(operator: &Operator, id: &str) -> anyhow::Result<Mailbox> {
+    let path = format!("/mailboxes/{}.json", id);
+    let json = operator
+        .read(&path)
+        .await
+        .with_context(|| format!("Error reading mailbox {}", id))?;
+
+    let mailbox = serde_json::from_slice::<Mailbox>(&json)
+        .with_context(|| format!("Error deserializing mailbox {}", id))?;
+
+    Ok(mailbox)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,8 +71,28 @@ async fn main() -> anyhow::Result<()> {
                 std::process::exit(1);
             })
         }
+        Some(Commands::Restore { cmd } ) => {
+                        // We need to configure the jmap client and operator for backup to work
+            conf.set_jmap_secret()?;
+            conf.set_storage_secret()?;
+
+            let client = create_client(conf.jmap).await.unwrap_or_else(|e| {
+                let err = format!("{}", e);
+                error!("{}", style(err).red().bold());
+                std::process::exit(1);
+            });
+
+            let operator = create_storage_backend(conf.storage.scheme.into(), conf.storage.config).unwrap_or_else(|e| {
+                let err = format!("{}", e);
+                error!("{}", style(err).red().bold());
+                std::process::exit(1);
+            });
+
+            // TODO: Implement subcommands for restore
+            Ok(())
+        }
         Some(Commands::Status {}) => {
-            return Ok(());
+            Ok(())
         }
         Some(Commands::Search { query, fields, limit }) => {
             if let Some(search) = conf.search {


### PR DESCRIPTION
Initial work on email restoration command. It will restore the specified emails and any associated mailboxes. Implements logic for diffing mailboxes and figuring out what needs to be restored.

Uses topological sort to ensure mailboxes are created in the right order (can't specify parents that do not exist).